### PR TITLE
added workaround for DecapAttack messed up C + START buttons pressed detection

### DIFF
--- a/src/cores/picodrive/pico/memory.c
+++ b/src/cores/picodrive/pico/memory.c
@@ -277,7 +277,13 @@ static NOINLINE u32 port_read(int i)
   u32 in, out;
 
   out = data_reg & ctrl_reg;
-  out |= 0x7f & ~ctrl_reg; // pull-ups
+  //out |= 0x7f & ~ctrl_reg; // pull-ups
+
+  // pull-ups: should be 0x7f, but Decap Attack has a bug where it temporarily
+  // disables output before doing TH-low read, so it doesn't emulate it for TH.
+  // Decap Attack reportedly doesn't work on Nomad but works on most
+  // other MD revisions (different pull-up strength?). This is a hack:
+  out |= 0x3f & ~ctrl_reg;
 
   in = port_readers[i](i, out);
 


### PR DESCRIPTION
This hack was created by notaz and committed to the official picodrive code on Oct 13, 2020  as per https://github.com/notaz/picodrive/commit/1d366b1ad9362fd463c42979c8a687dfc7f46c46

I've built it with this modification and buttons work fine for DecapAttack on old 3DS. Other games also work fine so does not seem to affect regular use of controller buttons. 

This pull request is to address https://github.com/bubble2k16/emus3ds/issues/37